### PR TITLE
fix too long tooltips

### DIFF
--- a/dlgPreferencesHelp.ui
+++ b/dlgPreferencesHelp.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>520</width>
-    <height>496</height>
+    <height>384</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,7 +30,10 @@
       <item row="1" column="1">
        <widget class="Gui::PrefLineEdit" name="lineEdit_2">
         <property name="toolTip">
-         <string>If you are using a documentation source that uses suffixes for languages, for example https://wiki.freecad.org, and wishes to use a transalted version, you can indicate it here, for example: /fr</string>
+         <string>If the documentation source supports page suffixes
+for languages, for example https://wiki.freecad.org,
+and wish to use a translated version, indicate it here,
+for example by entering &quot;fr&quot; to get French.</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>Suffix</cstring>
@@ -56,7 +59,11 @@
       <item row="2" column="1">
        <widget class="Gui::PrefFileChooser" name="fileChooser">
         <property name="toolTip">
-         <string>Set this to the base folder where the markdown help files are located. You can easily download the documentation by using the Addons Manager and installing the &quot;documentation&quot; addon. If this field is left blank, FreeCAD will automatically search for the help files at the default location when installed via the Addons Manager ( $USERAPPDATADIR/Mod/Documentation )</string>
+         <string>Set this to the base folder where the markdown help files are located.
+You can easily download the documentation by using the Addons Manager
+and installing the &quot;documentation&quot; addon. If this field is left blank, FreeCAD
+will automatically search for the help files at the default location when
+installed via the Addons Manager ( $USERAPPDATADIR/Mod/Documentation ).</string>
         </property>
         <property name="fileName">
          <string/>
@@ -72,7 +79,12 @@
       <item row="0" column="1">
        <widget class="Gui::PrefLineEdit" name="lineEdit">
         <property name="toolTip">
-         <string>The online location of help files. If left empty, FreeCAD will automatically retrieve the documentation from its default location. You can also point this to any other repository containing markdown or html files, or the base URL of a wiki (use &quot;https://wiki.freecadweb.org&quot; for the default FreeCAD wiki).</string>
+         <string>The online location of help files.
+If left empty, FreeCAD will automatically retrieve the documentation
+from its default location.
+You can also point this to any other repository containing markdown
+or html files, or the base URL of a wiki (use &quot;https://wiki.freecad.org&quot;
+for the default FreeCAD wiki).</string>
         </property>
         <property name="placeholderText">
          <string>automatic</string>
@@ -184,22 +196,6 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_4">
       <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox">
-        <property name="toolTip">
-         <string>If this is checked, the Help and What's this? commands will use the Help module.</string>
-        </property>
-        <property name="text">
-         <string>Use the Help module (temporary)</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>UseHelpModule</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Help</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="label">
@@ -211,7 +207,8 @@
         <item>
          <widget class="Gui::PrefFileChooser" name="styleSheet">
           <property name="toolTip">
-           <string>You can here indicate the path to an alternative CSS file to be used to style the markdown pages. This has no effect if the &quot;Force HTML mode&quot; optin above is used.</string>
+           <string>You can here indicate the path to an alternative CSS file
+to be used to style the markdown pages.</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>StyleSheet</cstring>
@@ -255,11 +252,6 @@
   <customwidget>
    <class>Gui::PrefRadioButton</class>
    <extends>QRadioButton</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefCheckBox</class>
-   <extends>QCheckBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>


### PR DESCRIPTION
- I got a report that the tooltips are too long and one was misleading
- I was also informed that the "use help module" option should be removed since it has no effect
- 
This PR does therefore remove the "use help module" option and changes the tooltips